### PR TITLE
Replace Edge with an Option of a Node Pointer struct, rename Node to RawNode

### DIFF
--- a/binary_search_tree/src/lib.rs
+++ b/binary_search_tree/src/lib.rs
@@ -3,15 +3,21 @@ use std::cell::RefCell;
 use std::cell::Ref;
 
 #[derive(Debug)]
-pub struct NodePtr(Rc<RefCell<Node>>);
+pub struct NodePtr(Rc<RefCell<RawNode>>);
 
 impl NodePtr {
     pub fn new(key: usize, value: String) -> Self {
-        let node = Rc::new(RefCell::new(Node::new(key, value)));
+        let node = Rc::new(RefCell::new(RawNode {
+            key,
+            value,
+            left: None,
+            right: None,
+            size: 1,
+        }));
         NodePtr(node)
     }
 
-    pub fn node(&self) -> Ref<Node> {
+    pub fn node(&self) -> Ref<RawNode> {
         self.0.borrow()
     }
 
@@ -30,27 +36,6 @@ impl NodePtr {
     pub fn clone(&self) -> Self {
         NodePtr(Rc::clone(&self.0))
     }
-}
-
-#[derive(Debug)]
-pub struct Node {
-    key: usize,
-    value: String,
-    left: Option<NodePtr>,
-    right: Option<NodePtr>,
-    size: usize,
-}
-
-impl Node {
-    pub fn new(key: usize, value: String) -> Self {
-        Node {
-            key,
-            value,
-            left: None,
-            right: None,
-            size: 1,
-        }
-    }
 
     pub fn size(node: &Option<NodePtr>) -> usize {
         match node {
@@ -58,6 +43,15 @@ impl Node {
             None => 0,
         }
     }
+}
+
+#[derive(Debug)]
+pub struct RawNode {
+    key: usize,
+    value: String,
+    left: Option<NodePtr>,
+    right: Option<NodePtr>,
+    size: usize,
 }
 
 #[derive(Debug)]
@@ -71,11 +65,11 @@ impl BST {
     }
 
     pub fn is_empty(&self) -> bool {
-        Node::size(&self.root) == 0
+        NodePtr::size(&self.root) == 0
     }
 
     pub fn size(&self) -> usize {
-        Node::size(&self.root)
+        NodePtr::size(&self.root)
     }
 
     pub fn get(&self, key: usize) -> Option<String> {
@@ -109,7 +103,7 @@ impl BST {
                 node_ptr.set_right(new_node);
             }
             // TODO: if same key, update value
-            let size = 1 + Node::size(&node_ptr.node().left) + Node::size(&node_ptr.node().right);
+            let size = 1 + NodePtr::size(&node_ptr.node().left) + NodePtr::size(&node_ptr.node().right);
             node_ptr.set_size(size);
             return Some(node_ptr.clone());
         }
@@ -131,7 +125,7 @@ impl BST {
             }
             let new_node = BST::remove_min(&node_ptr.node().left);
             node_ptr.set_left(new_node);
-            let size = 1 + Node::size(&node_ptr.node().left) + Node::size(&node_ptr.node().right);
+            let size = 1 + NodePtr::size(&node_ptr.node().left) + NodePtr::size(&node_ptr.node().right);
             node_ptr.set_size(size);
             return Some(node_ptr.clone());
         }
@@ -208,9 +202,9 @@ mod tests {
 
     #[test]
     fn create_node() {
-        let n = Node::new(1, "a".to_string());
-        assert_eq!(n.left.is_none(), true);
-        assert_eq!(n.right.is_none(), true);
+        let n = NodePtr::new(1, "a".to_string());
+        assert_eq!(n.node().left.is_none(), true);
+        assert_eq!(n.node().right.is_none(), true);
     }
 
     #[test]

--- a/binary_search_tree/src/lib.rs
+++ b/binary_search_tree/src/lib.rs
@@ -2,28 +2,12 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 #[derive(Debug)]
-enum Edge {
-    Null,
-    Link(Rc<RefCell<Node>>),
-}
+pub struct NodePtr(Rc<RefCell<Node>>);
 
-impl Edge {
+impl NodePtr {
     pub fn new(key: usize, value: String) -> Self {
-        Edge::Link(Rc::new(RefCell::new(Node::new(key, value))))
-    }
-
-    pub fn is_null(&self) -> bool {
-        match *self {
-            Edge::Link(_) => false,
-            Edge::Null => true,
-        }
-    }
-
-    pub fn size(&self) -> usize {
-        match self {
-            Edge::Link(node) => node.borrow().size,
-            Edge::Null => 0,
-        }
+        let node = Rc::new(RefCell::new(Node::new(key, value)));
+        NodePtr(node)
     }
 }
 
@@ -31,8 +15,8 @@ impl Edge {
 pub struct Node {
     key: usize,
     value: String,
-    left: Edge,
-    right: Edge,
+    left: Option<NodePtr>,
+    right: Option<NodePtr>,
     size: usize,
 }
 
@@ -41,43 +25,50 @@ impl Node {
         Node {
             key,
             value,
-            left: Edge::Null,
-            right: Edge::Null,
+            left: None,
+            right: None,
             size: 1,
+        }
+    }
+
+    pub fn size(node: &Option<NodePtr>) -> usize {
+        match node {
+            Some(node) => node.0.borrow().size,
+            None => 0,
         }
     }
 }
 
 #[derive(Debug)]
 pub struct BST {
-    root: Edge,
+    root: Option<NodePtr>,
 }
 
 impl BST {
     pub fn new() -> Self {
-        BST { root: Edge::Null }
+        BST { root: None }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.root.size() == 0
+        Node::size(&self.root) == 0
     }
 
     pub fn size(&self) -> usize {
-        self.root.size()
+        Node::size(&self.root)
     }
 
     pub fn get(&self, key: usize) -> Option<String> {
         BST::getr(&self.root, key)
     }
 
-    fn getr(x: &Edge, key: usize) -> Option<String> {
-        if let Edge::Link(node) = x {
-            if key < node.borrow().key {
-                return BST::getr(&node.borrow().left, key);
-            } else if key > node.borrow().key {
-                return BST::getr(&node.borrow().right, key);
+    fn getr(x: &Option<NodePtr>, key: usize) -> Option<String> {
+        if let Some(node) = x {
+            if key < node.0.borrow().key {
+                return BST::getr(&node.0.borrow().left, key);
+            } else if key > node.0.borrow().key {
+                return BST::getr(&node.0.borrow().right, key);
             } else {
-                return Some(node.borrow().value.clone());
+                return Some(node.0.borrow().value.clone());
             }
         }
         None
@@ -87,63 +78,63 @@ impl BST {
         self.root = BST::insert(&self.root, key, value);
     }
 
-    fn insert(x: &Edge, key: usize, value: String) -> Edge {
-        if let Edge::Link(node) = x {
-            if key < node.borrow().key {
-                let new_node = BST::insert(&node.borrow().left, key, value);
-                node.borrow_mut().left = new_node;
-            } else if key > node.borrow().key {
-                let new_node = BST::insert(&node.borrow().right, key, value);
-                node.borrow_mut().right = new_node;
+    fn insert(x: &Option<NodePtr>, key: usize, value: String) -> Option<NodePtr> {
+        if let Some(node) = x {
+            if key < node.0.borrow().key {
+                let new_node = BST::insert(&node.0.borrow().left, key, value);
+                node.0.borrow_mut().left = new_node;
+            } else if key > node.0.borrow().key {
+                let new_node = BST::insert(&node.0.borrow().right, key, value);
+                node.0.borrow_mut().right = new_node;
             }
             // TODO: if same key, update value
-            let size = 1 + node.borrow().left.size() + node.borrow().right.size();
-            node.borrow_mut().size = size;
-            return Edge::Link(Rc::clone(node));
+            let size = 1 + Node::size(&node.0.borrow().left) + Node::size(&node.0.borrow().right);
+            node.0.borrow_mut().size = size;
+            return Some(NodePtr(Rc::clone(&node.0)));
         }
         // x = Null
-        Edge::new(key, value)
+        Some(NodePtr::new(key, value))
     }
 
     pub fn delete_min(&mut self) {
         self.root = BST::remove_min(&self.root);
     }
 
-    fn remove_min(x: &Edge) -> Edge {
-        if let Edge::Link(node) = x {
-            if node.borrow().left.is_null() {
-                match &node.borrow().right {
-                    Edge::Link(node) => return Edge::Link(Rc::clone(node)),
-                    Edge::Null => return Edge::Null,
+    fn remove_min(x: &Option<NodePtr>) -> Option<NodePtr> {
+        if let Some(node) = x {
+            if node.0.borrow().left.is_none() {
+                match &node.0.borrow().right {
+                    Some(node) => return Some(NodePtr(Rc::clone(&node.0))),
+                    None => return None,
                 }
             }
-            let new_node = BST::remove_min(&node.borrow().left);
-            node.borrow_mut().left = new_node;
-            let size = 1 + node.borrow().left.size() + node.borrow().right.size();
-            node.borrow_mut().size = size;
-            return Edge::Link(Rc::clone(node));
+            let new_node = BST::remove_min(&node.0.borrow().left);
+            node.0.borrow_mut().left = new_node;
+            let size = 1 + Node::size(&node.0.borrow().left) + Node::size(&node.0.borrow().right);
+            node.0.borrow_mut().size = size;
+            return Some(NodePtr(Rc::clone(&node.0)));
         }
-        Edge::Null
+        None
     }
 
     pub fn min(&self) -> Option<usize> {
-        if let Edge::Link(node) = BST::minimum(&self.root) {
-            return Some(node.borrow().key)
+        if let Some(node) = BST::minimum(&self.root) {
+            return Some(node.0.borrow().key)
         }
 
         None
     }
 
-    fn minimum(x: &Edge) -> Edge {
-        if let Edge::Link(node) = x {
-            if node.borrow().left.is_null() {
-                return Edge::Link(Rc::clone(node));
+    fn minimum(x: &Option<NodePtr>) -> Option<NodePtr> {
+        if let Some(node) = x {
+            if node.0.borrow().left.is_none() {
+                return Some(NodePtr(Rc::clone(&node.0)));
             } else {
-                return BST::minimum(&node.borrow().left);
+                return BST::minimum(&node.0.borrow().left);
             }
         }
 
-        Edge::Null
+        None
     }
 
     pub fn keys(&self) -> Vec<usize> {
@@ -152,11 +143,11 @@ impl BST {
         v
     }
 
-    fn inorder(x: &Edge, v: &mut Vec<usize>) {
-        if let Edge::Link(node) = x {
-            BST::inorder(&node.borrow().left, v);
-            v.push(node.borrow().key);
-            BST::inorder(&node.borrow().right, v);
+    fn inorder(x: &Option<NodePtr>, v: &mut Vec<usize>) {
+        if let Some(node) = x {
+            BST::inorder(&node.0.borrow().left, v);
+            v.push(node.0.borrow().key);
+            BST::inorder(&node.0.borrow().right, v);
         }
     }
 }
@@ -165,9 +156,9 @@ impl BST {
 mod tests {
     use super::*;
 
-    fn check_key(cell: &Edge, key: usize) {
-        if let Edge::Link(node) = cell {
-            assert_eq!(node.borrow().key, key);
+    fn check_key(cell: &Option<NodePtr>, key: usize) {
+        if let Some(node) = cell {
+            assert_eq!(node.0.borrow().key, key);
         } else {
             panic!("Node can't be None");
         }
@@ -197,14 +188,14 @@ mod tests {
     #[test]
     fn create_node() {
         let n = Node::new(1, "a".to_string());
-        assert_eq!(n.left.is_null(), true);
-        assert_eq!(n.right.is_null(), true);
+        assert_eq!(n.left.is_none(), true);
+        assert_eq!(n.right.is_none(), true);
     }
 
     #[test]
     fn build_tree() {
         let mut bst = BST::new();
-        assert_eq!(bst.root.is_null(), true);
+        assert_eq!(bst.root.is_none(), true);
 
         // New node becomes root
         bst.put(2, "b".to_string());
@@ -212,16 +203,16 @@ mod tests {
 
         // New node becomes left node
         bst.put(1, "a".to_string());
-        if let Edge::Link(node) = &bst.root {
-            check_key(&node.borrow().left, 1);
+        if let Some(node) = &bst.root {
+            check_key(&node.0.borrow().left, 1);
         } else {
             panic!("BST must have root");
         }
 
         // New node becomes right node
         bst.put(3, "c".to_string());
-        if let Edge::Link(node) = &bst.root {
-            check_key(&node.borrow().right, 3);
+        if let Some(node) = &bst.root {
+            check_key(&node.0.borrow().right, 3);
         } else {
             panic!("BST must have root");
         }

--- a/binary_search_tree/src/lib.rs
+++ b/binary_search_tree/src/lib.rs
@@ -3,9 +3,9 @@ use std::cell::RefCell;
 use std::cell::Ref;
 
 #[derive(Debug)]
-pub struct NodePtr(Rc<RefCell<RawNode>>);
+pub struct Node(Rc<RefCell<RawNode>>);
 
-impl NodePtr {
+impl Node {
     pub fn new(key: usize, value: String) -> Self {
         let node = Rc::new(RefCell::new(RawNode {
             key,
@@ -14,18 +14,18 @@ impl NodePtr {
             right: None,
             size: 1,
         }));
-        NodePtr(node)
+        Node(node)
     }
 
-    pub fn node(&self) -> Ref<RawNode> {
+    pub fn get(&self) -> Ref<RawNode> {
         self.0.borrow()
     }
 
-    pub fn set_left(&self, node: Option<NodePtr>) {
+    pub fn set_left(&self, node: Option<Node>) {
         self.0.borrow_mut().left = node;
     }
 
-    pub fn set_right(&self, node: Option<NodePtr>) {
+    pub fn set_right(&self, node: Option<Node>) {
         self.0.borrow_mut().right = node;
     }
 
@@ -34,10 +34,10 @@ impl NodePtr {
     }
 
     pub fn clone(&self) -> Self {
-        NodePtr(Rc::clone(&self.0))
+        Node(Rc::clone(&self.0))
     }
 
-    pub fn size(node: &Option<NodePtr>) -> usize {
+    pub fn size(node: &Option<Node>) -> usize {
         match node {
             Some(node) => node.0.borrow().size,
             None => 0,
@@ -49,14 +49,14 @@ impl NodePtr {
 pub struct RawNode {
     key: usize,
     value: String,
-    left: Option<NodePtr>,
-    right: Option<NodePtr>,
+    left: Option<Node>,
+    right: Option<Node>,
     size: usize,
 }
 
 #[derive(Debug)]
 pub struct BST {
-    root: Option<NodePtr>,
+    root: Option<Node>,
 }
 
 impl BST {
@@ -65,25 +65,25 @@ impl BST {
     }
 
     pub fn is_empty(&self) -> bool {
-        NodePtr::size(&self.root) == 0
+        Node::size(&self.root) == 0
     }
 
     pub fn size(&self) -> usize {
-        NodePtr::size(&self.root)
+        Node::size(&self.root)
     }
 
     pub fn get(&self, key: usize) -> Option<String> {
         BST::getr(&self.root, key)
     }
 
-    fn getr(x: &Option<NodePtr>, key: usize) -> Option<String> {
-        if let Some(node_ptr) = x {
-            if key < node_ptr.node().key {
-                return BST::getr(&node_ptr.node().left, key);
-            } else if key > node_ptr.node().key {
-                return BST::getr(&node_ptr.node().right, key);
+    fn getr(x: &Option<Node>, key: usize) -> Option<String> {
+        if let Some(node) = x {
+            if key < node.get().key {
+                return BST::getr(&node.get().left, key);
+            } else if key > node.get().key {
+                return BST::getr(&node.get().right, key);
             } else {
-                return Some(node_ptr.node().value.clone());
+                return Some(node.get().value.clone());
             }
         }
         None
@@ -93,59 +93,59 @@ impl BST {
         self.root = BST::insert(&self.root, key, value);
     }
 
-    fn insert(x: &Option<NodePtr>, key: usize, value: String) -> Option<NodePtr> {
-        if let Some(node_ptr) = x {
-            if key < node_ptr.node().key {
-                let new_node = BST::insert(&node_ptr.node().left, key, value);
-                node_ptr.set_left(new_node);
-            } else if key > node_ptr.node().key {
-                let new_node = BST::insert(&node_ptr.node().right, key, value);
-                node_ptr.set_right(new_node);
+    fn insert(x: &Option<Node>, key: usize, value: String) -> Option<Node> {
+        if let Some(node) = x {
+            if key < node.get().key {
+                let new_node = BST::insert(&node.get().left, key, value);
+                node.set_left(new_node);
+            } else if key > node.get().key {
+                let new_node = BST::insert(&node.get().right, key, value);
+                node.set_right(new_node);
             }
             // TODO: if same key, update value
-            let size = 1 + NodePtr::size(&node_ptr.node().left) + NodePtr::size(&node_ptr.node().right);
-            node_ptr.set_size(size);
-            return Some(node_ptr.clone());
+            let size = 1 + Node::size(&node.get().left) + Node::size(&node.get().right);
+            node.set_size(size);
+            return Some(node.clone());
         }
         // x = Null
-        Some(NodePtr::new(key, value))
+        Some(Node::new(key, value))
     }
 
     pub fn delete_min(&mut self) {
         self.root = BST::remove_min(&self.root);
     }
 
-    fn remove_min(x: &Option<NodePtr>) -> Option<NodePtr> {
-        if let Some(node_ptr) = x {
-            if node_ptr.node().left.is_none() {
-                match &node_ptr.node().right {
-                    Some(node_ptr) => return Some(node_ptr.clone()),
+    fn remove_min(x: &Option<Node>) -> Option<Node> {
+        if let Some(node) = x {
+            if node.get().left.is_none() {
+                match &node.get().right {
+                    Some(node) => return Some(node.clone()),
                     None => return None,
                 }
             }
-            let new_node = BST::remove_min(&node_ptr.node().left);
-            node_ptr.set_left(new_node);
-            let size = 1 + NodePtr::size(&node_ptr.node().left) + NodePtr::size(&node_ptr.node().right);
-            node_ptr.set_size(size);
-            return Some(node_ptr.clone());
+            let new_node = BST::remove_min(&node.get().left);
+            node.set_left(new_node);
+            let size = 1 + Node::size(&node.get().left) + Node::size(&node.get().right);
+            node.set_size(size);
+            return Some(node.clone());
         }
         None
     }
 
     pub fn min(&self) -> Option<usize> {
-        if let Some(node_ptr) = BST::minimum(&self.root) {
-            return Some(node_ptr.node().key)
+        if let Some(node) = BST::minimum(&self.root) {
+            return Some(node.get().key)
         }
 
         None
     }
 
-    fn minimum(x: &Option<NodePtr>) -> Option<NodePtr> {
-        if let Some(node_ptr) = x {
-            if node_ptr.node().left.is_none() {
-                return Some(node_ptr.clone());
+    fn minimum(x: &Option<Node>) -> Option<Node> {
+        if let Some(node) = x {
+            if node.get().left.is_none() {
+                return Some(node.clone());
             } else {
-                return BST::minimum(&node_ptr.node().left);
+                return BST::minimum(&node.get().left);
             }
         }
 
@@ -158,11 +158,11 @@ impl BST {
         v
     }
 
-    fn inorder(x: &Option<NodePtr>, v: &mut Vec<usize>) {
-        if let Some(node_ptr) = x {
-            BST::inorder(&node_ptr.node().left, v);
-            v.push(node_ptr.node().key);
-            BST::inorder(&node_ptr.node().right, v);
+    fn inorder(x: &Option<Node>, v: &mut Vec<usize>) {
+        if let Some(node) = x {
+            BST::inorder(&node.get().left, v);
+            v.push(node.get().key);
+            BST::inorder(&node.get().right, v);
         }
     }
 }
@@ -171,9 +171,9 @@ impl BST {
 mod tests {
     use super::*;
 
-    fn check_key(cell: &Option<NodePtr>, key: usize) {
-        if let Some(node_ptr) = cell {
-            assert_eq!(node_ptr.node().key, key);
+    fn check_key(cell: &Option<Node>, key: usize) {
+        if let Some(node) = cell {
+            assert_eq!(node.get().key, key);
         } else {
             panic!("Node can't be None");
         }
@@ -202,9 +202,9 @@ mod tests {
 
     #[test]
     fn create_node() {
-        let n = NodePtr::new(1, "a".to_string());
-        assert_eq!(n.node().left.is_none(), true);
-        assert_eq!(n.node().right.is_none(), true);
+        let n = Node::new(1, "a".to_string());
+        assert_eq!(n.get().left.is_none(), true);
+        assert_eq!(n.get().right.is_none(), true);
     }
 
     #[test]
@@ -218,16 +218,16 @@ mod tests {
 
         // New node becomes left node
         bst.put(1, "a".to_string());
-        if let Some(node_ptr) = &bst.root {
-            check_key(&node_ptr.node().left, 1);
+        if let Some(node) = &bst.root {
+            check_key(&node.get().left, 1);
         } else {
             panic!("BST must have root");
         }
 
         // New node becomes right node
         bst.put(3, "c".to_string());
-        if let Some(node_ptr) = &bst.root {
-            check_key(&node_ptr.node().right, 3);
+        if let Some(node) = &bst.root {
+            check_key(&node.get().right, 3);
         } else {
             panic!("BST must have root");
         }

--- a/binary_search_tree/src/lib.rs
+++ b/binary_search_tree/src/lib.rs
@@ -26,6 +26,10 @@ impl NodePtr {
     pub fn set_size(&self, size: usize) {
         self.0.borrow_mut().size = size;
     }
+
+    pub fn clone(&self) -> Self {
+        NodePtr(Rc::clone(&self.0))
+    }
 }
 
 #[derive(Debug)]
@@ -107,7 +111,7 @@ impl BST {
             // TODO: if same key, update value
             let size = 1 + Node::size(&node_ptr.node().left) + Node::size(&node_ptr.node().right);
             node_ptr.set_size(size);
-            return Some(NodePtr(Rc::clone(&node_ptr.0)));
+            return Some(node_ptr.clone());
         }
         // x = Null
         Some(NodePtr::new(key, value))
@@ -121,7 +125,7 @@ impl BST {
         if let Some(node_ptr) = x {
             if node_ptr.node().left.is_none() {
                 match &node_ptr.node().right {
-                    Some(node) => return Some(NodePtr(Rc::clone(&node.0))),
+                    Some(node_ptr) => return Some(node_ptr.clone()),
                     None => return None,
                 }
             }
@@ -129,7 +133,7 @@ impl BST {
             node_ptr.set_left(new_node);
             let size = 1 + Node::size(&node_ptr.node().left) + Node::size(&node_ptr.node().right);
             node_ptr.set_size(size);
-            return Some(NodePtr(Rc::clone(&node_ptr.0)));
+            return Some(node_ptr.clone());
         }
         None
     }
@@ -145,7 +149,7 @@ impl BST {
     fn minimum(x: &Option<NodePtr>) -> Option<NodePtr> {
         if let Some(node_ptr) = x {
             if node_ptr.node().left.is_none() {
-                return Some(NodePtr(Rc::clone(&node_ptr.0)));
+                return Some(node_ptr.clone());
             } else {
                 return BST::minimum(&node_ptr.node().left);
             }


### PR DESCRIPTION
This is a significant refactor replacing `Edge` enum with an `Option` of a node pointer struct initially named `NodePtr`:

```rust
// Edge can be a Null or a Link
Edge::Link(Rc<RefCell<Node>>)

// NodePtr is a tuple-like struct
NodePtr(Rc<RefCell<Node>>)
// optional node pointer
Option<NodePtr>
```

The `Node` struct was renamed to `RawNode`, and the node pointer struct renamed to `Node`:

```rust
pub struct RawNode {
    key: usize,
    value: String,
    left: Option<Node>,
    right: Option<Node>,
    size: usize,
}

pub struct Node(Rc<RefCell<RawNode>>);
```

The following helper methods were added to the node pointer struct `Node`:

* `get` - returns a `Ref<RawNode>`, used instead of `node_ptr.0.borrow()`
* `set_left` - instead of `node_ptr.0.borrow_mut().left = `
* `set_right` - instead of `node_ptr.0.borrow_mut().right = `
* `set_size` - instead of `node_ptr.0.borrow_mut().size = `
* `clone` - instead of `Node(Rc::clone(&node_ptr.0))`
