### PR TITLE
API: MerkleTree::build

### DIFF
--- a/merkle_tree/Cargo.toml
+++ b/merkle_tree/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["mikong <4162+mikong@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
+sha2 = "0.8.0"

--- a/merkle_tree/src/lib.rs
+++ b/merkle_tree/src/lib.rs
@@ -1,27 +1,68 @@
+use std::mem;
+
 #[derive(Debug)]
-pub enum MerkleTree<T> {
+pub enum MerkleTree {
     Empty,
-    NonEmpty(Box<Node<T>>),
+    NonEmpty(Box<Node>),
 }
 
 #[derive(Debug)]
-pub struct Node<T> {
-    element: T,
-    left: MerkleTree<T>,
-    right: MerkleTree<T>,
+pub struct Node {
+    element: Vec<u8>,
+    left: MerkleTree,
+    right: MerkleTree,
+}
+
+impl MerkleTree {
+    pub fn build<T>(data: &Vec<T>) -> MerkleTree {
+        let mut leaf_nodes = data.iter().map(|_val| {
+            MerkleTree::NonEmpty(Box::new(Node {
+                element: vec![],
+                left: MerkleTree::Empty,
+                right: MerkleTree::Empty,
+            }))
+        }).collect();
+
+        MerkleTree::build_tree(&mut leaf_nodes)
+    }
+
+    fn build_tree(nodes: &mut Vec<MerkleTree>) -> MerkleTree {
+        let mut new_nodes = vec![];
+
+        for pair in nodes.chunks_exact_mut(2) {
+            let mut left = MerkleTree::Empty;
+            let mut right = MerkleTree::Empty;
+            mem::swap(&mut left, &mut pair[0]);
+            mem::swap(&mut right, &mut pair[1]);
+
+            let tree = MerkleTree::NonEmpty(Box::new(Node {
+                element: vec![],
+                left: left,
+                right: right,
+            }));
+
+            new_nodes.push(tree);
+        }
+
+        if nodes.len() % 2 == 1 {
+            new_nodes.push(nodes.pop().unwrap());
+        }
+
+        if new_nodes.len() == 1 {
+            return new_nodes.pop().unwrap();
+        }
+
+        MerkleTree::build_tree(&mut new_nodes)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::MerkleTree::*;
 
     #[test]
     fn it_works() {
-        let _tree = NonEmpty(Box::new(Node {
-            element: 5,
-            left: Empty,
-            right: Empty,
-        }));
+        let data = vec![1, 2, 3, 4, 5];
+        let _tree = MerkleTree::build(&data);
     }
 }


### PR DESCRIPTION
Notes:

* For now, we simply use SHA256 for this Merkle tree.
* The Node element that was previously a generic `T` is now a `GenericArray`, the return type for the `sha2` crate's SHA256 function.
* The function `new` is deliberately private and used simply as a helper function.

Added associated functions for `MerkleTree`:

* API: `build` - main function for creating a `MerkleTree`
* Helper: `build_tree` - recursive function for `build`
* Helper: `new` - private helper for creating a `MerkleTree`
* Helper: `concat_and_hash` - concatenates the elements of left and right nodes, and hashes the result. Returns a `GenericArray`
